### PR TITLE
Minor tweaks for clarification

### DIFF
--- a/wikitemplate.md
+++ b/wikitemplate.md
@@ -1,7 +1,7 @@
 ### Installer
 
-- [ ] Check that installer is close to the size of last release
-- [ ] Check signature: If OS Run `spctl --assess --verbose /Applications/Brave-Browser-Beta.app/` and make sure it returns `accepted`.  If Windows right click on the `brave_installer-x64.exe` and go to Properties, go to the Digital Signatures tab and double click on the signature.  Make sure it says "The digital signature is OK" in the popup window
+- [ ] Check the installer is close to the size of the last release
+- [ ] Check signature: On macOS, run `spctl --assess --verbose /Applications/Brave-Browser-Beta.app/` and make sure it returns `accepted`.  On Windows, right-click on the `brave_installer-x64.exe` and go to Properties, go to the Digital Signatures tab and double-click on the signature.  Make sure it says "The digital signature is OK" in the popup window
 
 ### About pages
 
@@ -9,9 +9,9 @@
 
 ### Importing
 
-- [ ] Verify that you can import `History`, `Favorites/Bookmarks` and `Passwords` from Google Chrome 
+- [ ] Verify that you can import `History`, `Favorites/Bookmarks` and `Passwords` from Google Chrome
 - [ ] Verify that you can import `History`, `Favorites/Bookmarks`, `Passwords`, `Search Engines` and `Autofill` from Firefox
-- [ ] Verify that you can import `Favorites/Bookmarks` from Mirosoft Edge
+- [ ] Verify that you can import `Favorites/Bookmarks` from Microsoft Edge
 - [ ] Verify that importing bookmarks using `Bookmark HTML File` retains the folder structure on a clean profile
 
 ### Context menus
@@ -22,23 +22,16 @@
 
 ### Extensions/Plugins
 
-- [ ] Verify pdfium, Torrent viewer extensions are installed automatically on fresh profile and cannot be disabled
+- [ ] Verify pdfium, Torrent viewer extensions are installed automatically on fresh profile and cannot be disabled (they don't show up in `brave://extensions`)
 - [ ] Verify older version of an extension gets updated to new version via Google server
-- [ ] Verify older version of an extension gets updated to new version via Brave server 
-- [ ] Verify that `magnet` links and `.torrent` files correctly opens WebTorrent and you're able to download the file(s)
-  - **Tip:** Free torrents available via https://webtorrent.io/torrents/
+- [ ] Verify older version of an extension gets updated to new version via Brave server
+- [ ] Verify that `magnet` links and `.torrent` files correctly open WebTorrent and you're able to download the file(s)
+  - **Tip:** Free torrents available via https://webtorrent.io/free-torrents
 
-### CWS
+### Chrome Web Store (CWS)
 
 - [ ] Verify that installing https://chrome.google.com/webstore/detail/adblock-plus-free-ad-bloc/cfhdojbkjhnklbpkdaibdccddilifddb from CWS displays the `Brave has not reviewed the extension.` warning via the "Add Extension" modal
 - [ ] Verify that installing https://chrome.google.com/webstore/detail/lastpass-free-password-ma/hdokiejnpimakedhajhdlcegeplioahd from CWS doesn't display the `Brave has not reviewed the extension.` warning via the "Add Extension" modal
-
-### Flash
-
-- [ ] Test that Flash gets blocked by default when installed
-- [ ] Test that once you allow Flash, it turns into a click to play area, and loads flash when allowed
-
-**Note:** Flash will no longer be supported after December 2020 as per https://blog.chromium.org/2017/07/so-long-and-thanks-for-all-flash.html.
 
 ### PDF
 
@@ -50,7 +43,7 @@
 ### Widevine
 
 - [ ] Verify `Widevine Notification` is shown when you visit Netflix for the first time
-- [ ] Test that you can stream on Netflix on a fresh profile after installing Widevine 
+- [ ] Test that you can stream on Netflix on a fresh profile after installing Widevine
 
 ### Geolocation
 
@@ -61,12 +54,12 @@
 
 - [ ] Check that loading `brave://crash` & `brave://gpucrash` causes the new tab to crash
 - [ ] Check that `brave://crashes` lists the `Uploaded Crash Report ID` once the report has been submitted
-- [ ] Verify the crash ID matches the report on BackTrace using `_rxid equal [ value ]`
+- [ ] Verify the crash ID matches the report on Backtrace using `_rxid equal [ value ]`
 
 ### Bravery settings
 
 - [ ] Verify that HTTPS Everywhere works by loading http://https-everywhere.badssl.com/
-- [ ] Turning HTTPS Everywhere off and shields off both disable the redirect to https://https-everywhere.badssl.com/
+- [ ] Turning HTTPS Everywhere off and Shields off both disable the redirect to https://https-everywhere.badssl.com/
 - [ ] Verify that toggling `Ads and trackers blocked` works as expected
 - [ ] Visit https://testsafebrowsing.appspot.com/s/phishing.html, verify that Safe Browsing (via our Proxy) works for all the listed items
 - [ ] Visit https://www.blizzard.com and then turn on script blocking, page should not load.
@@ -75,14 +68,14 @@
 
 ### Fingerprint Tests
 
-- [ ] Visit https://jsfiddle.net/bkf50r8v/13/, ensure 3 blocked items are listed in shields. Result window should show `got canvas fingerprint 0`  and  `got webgl fingerprint 00`
+- [ ] Visit https://jsfiddle.net/bkf50r8v/13/, ensure 3 blocked items are listed in Shields. Result window should show `got canvas fingerprint 0` and `got webgl fingerprint 00`
 - [ ] Test that audio fingerprint is blocked at https://audiofingerprint.openwpm.com/ only when `Block all fingerprinting protection` is on
-- [ ] Test that Brave browser isn't detected on https://www.whatismybrowser.com
+- [ ] Test that Brave browser isn't detected via user-agent, on https://www.whatismybrowser.com.  The site **will** say "Looks like Brave on [Windows/Linux/macOS]", and yet, "But it's announcing that it's Chrome [version] on [platform]"
 - [ ] Test that https://diafygi.github.io/webrtc-ips/ doesn't leak IP address when `Block all fingerprinting protection` is on
 
 ### Brave Ads
 
-- [ ] Verify when you enable Rewards from panel or brave://rewards, Ads are enabled by default
+- [ ] Verify when you enable Rewards from panel or `brave://rewards`, Ads are enabled by default
 - [ ] Verify Ads UI (panel, settings, etc) shows when in a region with Ads support
 - [ ] Verify Ads UI (panel, settings, etc) does not show when in a region without Ads support. Verify the Ads panel does show the 'Sorry! Ads are not yet available in your region.' message.
 - [ ] Verify when the system language is English, the Browser language is French, and you are in one of the supported regions, Ad notifications are still served to you.
@@ -90,9 +83,9 @@
   - [ ] Verify ad earnings are reflected in the rewards widget on the NTP.
 - [ ] Verify when Ads are toggled off, there are no Ad messages in the logs
 - [ ] Verify when Rewards are toggled off (but Ads were not explicitly toggled off), there are no Ads logs recorded
-- [ ] Verify view/click/dismiss/landed ad notifications show in confirmations.json
+- [ ] Verify view/click/dismiss/landed ad notifications show in `confirmations.json`
 - [ ] Verify pages you browse to are being classified in the logs
-- [ ] Verify tokens are redeemed by viewing the logs (you can use --rewards=debug=true to shorten redemption time) 
+- [ ] Verify tokens are redeemed by viewing the logs (you can use `--rewards=debug=true` to shorten redemption time)
 - [ ] Verify Ad is not shown if a tab is playing media and is only shown after it stops playing
 
 ### Rewards
@@ -105,9 +98,9 @@
 - [ ] Verify you are able to exclude a publisher from the auto-contribute table and popup list of sites.
 - [ ] Verify you are able to exclude a publisher by using the toggle on the Rewards Panel.
 - [ ] Verify you are able to perform an auto contribution.
-  - [ ] Verify auto contribution is reflected in the rewards widget on the NTP.
+  - [ ] Verify auto contribution is reflected in the rewards widget on the new-tab page (NTP).
 - [ ] Verify monthly statement shows expected data.
-- [ ] Verify when you click on the BR panel while on a site, the panel displays site specific information (site favicon, domain, attention %).
+- [ ] Verify when you click on the BR panel while on a site, the panel displays site-specific information (site favicon, domain, attention %).
 - [ ] Verify BR panel shows message about an unverified publisher.
 - [ ] Verify one time and monthly tip banners show a message about unverified publisher.
 - [ ] Verify one time tip and monthly tip banners show a verified checkmark for a verified creator.
@@ -130,9 +123,9 @@
 - [ ] Verify you can tip a verified Twitter user from the panel.
 - [ ] Verify you can tip a verified Twitter user via inline tip button.
   - [ ] Verify the in-line tip button is spaced properly.
-- [ ] Verify you can tip a verified Github user from the panel.
-- [ ] Verify you can tip a verified Github user via inline tip button.
-  - [ ] Verify the Github creator displays in the auto-contribute list after specified amount of time/visits per settings.
+- [ ] Verify you can tip a verified GitHub user from the panel.
+- [ ] Verify you can tip a verified GitHub user via inline tip button.
+  - [ ] Verify the GitHub creator displays in the auto-contribute list after specified amount of time/visits per settings.
 - [ ] Verify you can tip a verified Reddit user from the panel.
 - [ ] Verify you can tip a verified Reddit user via inline tip button.
 - [ ] Verify if you disable auto-contribute you are still able to tip creators.
@@ -142,8 +135,8 @@
 - [ ] Adjust min visit/time in settings. Visit some sites to verify they are added to the table after the specified settings.
 - [ ] Uphold cases
   - [ ] Verify you are able to connect a KYC'd Uphold wallet to Rewards.  
-  - [ ] Verify wallet balance in Brave updates when BAT is added to the Brave Browser card. 
-  - [ ] Verify if you only have user controlled BAT (BAT in Uphold only), you can only tip KYC'd creators, any tips to non-KYC'd creators go to the Pending Contributions list.
+  - [ ] Verify wallet balance in Brave updates when BAT is added to the Brave Browser card.
+  - [ ] Verify if you only have user-controlled BAT (BAT in Uphold only), you can only tip KYC'd creators, any tips to non-KYC'd creators go to the Pending Contributions list.
   - [ ] Verify connected (verified but not KYC'd) publishers display messaging on panel and tip banner.
   - [ ] Verify you are able to perform an auto contribute using Uphold BAT.
 
@@ -153,8 +146,8 @@
 - [ ] visit `brave://settings/privacy` -> `Site and Shields Settings` -> `Cookies and site data` and ensure that
   - [ ] both `https://[*.]firebaseapp.com` & `https://accounts.google.com` are added into `Sites that can always use cookies` when `Allow Google login buttons on third party sites` is enabled
   - [ ] both `https://[*.]firebaseapp.com` & `https://accounts.google.com` are removed from `Sites that can always use cookies` when `Allow Google login buttons on third party sites` is disabled
-- [ ] ensure that you can login into https://www.expensify.com while `Allow Google login buttons on third party sites` is enabled
-- [ ] ensure that once `Allow Google login buttons on third party sites` has been disabled, you can't login into https://www.expensify.com
+- [ ] ensure that you can log in into https://www.expensify.com while `Allow Google login buttons on third party sites` is enabled
+- [ ] ensure that once `Allow Google login buttons on third party sites` has been disabled, you can't log in into https://www.expensify.com
 
 ### Sync
 
@@ -168,17 +161,17 @@
 - [ ] Verify bookmarks don't duplicate when sync'd from other devices
 - [ ] Verify removing bookmark from device gets sync'd to all devices on the sync chain
 - [ ] Verify adding/removing a bookmark in offline mode gets sync'd to all devices on the sync chain when device comes online
-- [ ] With only two device in chain, verify removing the other device resets the sync on b-c as well
+- [ ] With only two devices in chain, verify removing the other device resets the sync on b-c as well
 
 ### Tor Tabs
 
-- [ ] Visit https://check.torproject.org in a Tor window, ensure its shows success message for using a Tor exit node
+- [ ] Visit https://check.torproject.org in a Tor window, ensure it shows a success message for using a Tor exit node
 - [ ] Visit https://check.torproject.org in a Tor window, note down exit node IP address. Do a hard refresh (Ctrl+Shift+R/Cmd+Shift+R), ensure exit IP changes after page reloads
 - [ ] Visit https://check.torproject.org in a Tor window, note down exit node IP address. Click `New Tor Identity for this site` in app menu, ensure the exit node IP address changes after page is reloaded
 - [ ] Visit https://protonirockerxow.onion & https://brave5t5rjjg3s6k.onion/ in a Tor window and ensure both pages resolve
 - [ ] Visit https://browserleaks.com/geo in a Tor window, ensure location isn't shown
 - [ ] Verify Torrent viewer doesn't load in a Tor window
-- [ ] Ensure you are able to download a file in Tor window. Verify all Download/Cancel, Download/Retry and Download works in Tor window
+- [ ] Ensure you are able to download a file in a Tor window. Verify all Download/Cancel, Download/Retry and Download works in Tor window
 
 ### Cookie and Cache
 
@@ -186,27 +179,27 @@
 
 ### Chromium/Brave GPU
 
-- Verify that `brave://gpu` (Brave) matches `chrome://gpu` (Chrome) when using the same Chromium version
+- [ ] Verify that `brave://gpu` (Brave) matches `chrome://gpu` (Chrome) when using the same Chromium version
 
 ### Components
 
-- [ ] Remove the following component folders and ensure that they're being re-downloaded after restarting the browser
-  - [ ] `AutoplayWhitelist.dat`, `ExtensionWhitelist.dat`, `ReferrerWhitelist.json` and `Greaselion.json`
-  - [ ] CertificateRevocation
-  - [ ] `rs-ABPFilterParserData.dat` & `regional_catalog.json` (AdBlock)
-  - [ ] Sponsored New Tab Images
-  - [ ] `speedreader-updater.dat`
-  - [ ] HTTPSE
-  - [ ] Safe Browsing
-- [ ] Restart the browser, load brave://components, wait for 8 mins and verify that no component shows any errors
+- [ ] Remove the following component folders and ensure that they're being re-downloaded after restarting the browser:
+  - [ ] `afalakplffnnnlkncjhbmahjfjhmlkal`: `AutoplayWhitelist.dat`, `ExtensionWhitelist.dat`, `ReferrerWhitelist.json` and `Greaselion.json`
+  - [ ] `CertificateRevocation`
+  - [ ] `cffkpbalmllkdoenhmdmpbkajipdjfam`: `rs-ABPFilterParserData.dat` & `regional_catalog.json` (AdBlock)
+  - [ ] `gccbbckogglekeggclmmekihdgdpdgoe`: (Sponsored New Tab Images)
+  - [ ] `jicbkmdloagakknpihibphagfckhjdih`: `speedreader-updater.dat`
+  - [ ] `oofiananboodjbbmdelgdommihjbkfag`: HTTPSE
+  - [ ] `Safe Browsing`
+- [ ] Restart the browser, load `brave://components`, wait for 8 mins and verify that no component shows any errors
 
 **Note:** Always double check `brave://components` to make sure there's no errors/missing version numbers
 
 ### Session storage
 
-- [ ] Temporarily move away your browser profile and test that a new profile is created when browser is launched 
+- [ ] Temporarily move away your browser profile and test that a new profile is created on browser relaunch
   - macOS - `~/Library/Application\ Support/BraveSoftware/`
-  - Windows - `%userprofile%\appdata\Local\BraveSoftware\` 
+  - Windows - `%userprofile%\appdata\Local\BraveSoftware\`
   - Linux(Ubuntu) - `~/.config/BraveSoftware/`
 - [ ] Test that both windows and tabs are being restored, including the current active tab
 - [ ] Ensure that tabs are being lazy loaded when a previous session is being restored
@@ -215,14 +208,14 @@
 
 - [ ] Make sure that data from the last version appears in the new version OK
 - [ ] Ensure that `brave://version` lists the expected Brave & Chromium versions
-- [ ] With data from the last version, verify that
+- [ ] With data from the last version, verify that:
   - [ ] Bookmarks on the bookmark toolbar and bookmark folders can be opened
   - [ ] Cookies are preserved
   - [ ] Installed extensions are retained and work correctly
   - [ ] Opened tabs can be reloaded
   - [ ] Stored passwords are preserved
-  - [ ] Sync chain created in previous version is retained 
-  - [ ] Social media blocking buttons changes are retained
+  - [ ] Sync chain created in previous version is retained
+  - [ ] Social media-blocking buttons changes are retained
   - [ ] Rewards
     - [ ] Wallet balance is retained
     - [ ] Auto-contribute list is retained


### PR DESCRIPTION
* substituted https://torrent.ubuntu.com/ for the 404'ing https://webtorrent.io/torrents link
* spelling fixes, including pedantic s/login/log in (noun vs. verb), s/Github/GitHub, etc.
* upper-cased Shields, so it stands out as the feature/proper noun I think it is
* hyphenation for things like `right-click`
* added folder/directory names for removed and automatically re-populated components
* disambiguated Chrome Web Store in the heading

And a few more; should be minor, but please nit-pick away!