### PR TITLE
Add macOS arm64/M1 specific test pass template

### DIFF
--- a/wikitemplate-macOS-arm64.md
+++ b/wikitemplate-macOS-arm64.md
@@ -40,6 +40,7 @@
     - [ ] Both Tips and Monthly Contributions are retained
     - [ ] Wallet panel transactions list is retained
     - [ ] Changes to rewards settings are retained
+    - [ ] Ensure that Auto Contribute is not being enabled when upgrading to a new version if AC was disabled
   - [ ] Ads
     - [ ] Both `Estimated pending rewards` & `Ad notifications received this month` are retained
     - [ ] Changes to ads settings are retained
@@ -64,6 +65,7 @@
     - [ ] Both Tips and Monthly Contributions are retained
     - [ ] Wallet panel transactions list is retained
     - [ ] Changes to rewards settings are retained
+    - [ ] Ensure that Auto Contribute is not being enabled when upgrading to a new version if AC was disabled
   - [ ] Ads
     - [ ] Both `Estimated pending rewards` & `Ad notifications received this month` are retained
     - [ ] Changes to ads settings are retained

--- a/wikitemplate-macOS-arm64.md
+++ b/wikitemplate-macOS-arm64.md
@@ -1,0 +1,71 @@
+### Installer
+
+- [ ]  Check signature: If OS Run `"spctl --assess --verbose /Applications/Brave Browser.app"` and make sure it returns `accepted`.
+- [ ] Ensured that the following executables work as expected
+   - [ ] `Brave-Browser-universal.dmg`
+      - [ ] Check executable size, should be `~470mb`
+   - [ ] `Brave-Browser-universal.pkg`
+       - [ ] Check executable size, should be `~470mb`
+   - [ ] `Brave-Browser-x64.dmg`
+       - [ ] Check executable size, should be `~270mb`
+   - [ ] `Brave-Browser-x64.pkg`
+       - [ ] Check executable size, should be `~270mb`
+- [ ] Visited `brave://version` and ensure the following:
+   - [ ] `arm64` is being displayed when installing via `universal` binary on `M1` mac
+   - [ ] `x86_64 translated` is being displayed when installing via `x64` binary on `M1` mac using `Rosetta`
+
+### Widevine
+
+- [ ]  Verify `Widevine Notification` is shown when you visit Netflix for the first time
+- [ ]  Test that you can stream on Netflix on a fresh profile after installing Widevine 
+
+#### Components
+- [ ]   Delete Adblock folder from browser profile and restart browser. Visit `brave://components` and verify `Brave Ad Block Updater` downloads and update the component. Repeat for all Brave components
+
+#### Upgrade - `Brave-Browser-universal.dmg`
+
+- [ ] Make sure that data from the last version appears in the new version OK
+- [ ] Ensure that `brave://version` lists the expected Brave & Chromium versions
+- [ ] With data from the last version, verify that
+  - [ ] Bookmarks on the bookmark toolbar and bookmark folders can be opened
+  - [ ] Cookies are preserved
+  - [ ] Installed extensions are retained and work correctly
+  - [ ] Opened tabs can be reloaded
+  - [ ] Stored passwords are preserved
+  - [ ] Sync chain created in previous version is retained 
+  - [ ] Social media blocking buttons changes are retained
+  - [ ] Rewards
+    - [ ] Wallet balance is retained
+    - [ ] Auto-contribute list is retained
+    - [ ] Both Tips and Monthly Contributions are retained
+    - [ ] Wallet panel transactions list is retained
+    - [ ] Changes to rewards settings are retained
+  - [ ] Ads
+    - [ ] Both `Estimated pending rewards` & `Ad notifications received this month` are retained
+    - [ ] Changes to ads settings are retained
+    - [ ] Ensure that ads are not being enabled when upgrading to a new version if they were disabled
+    - [ ] Ensure that ads are not disabled when upgrading to a new version if they were enabled 
+
+#### Upgrade - `Brave-Browser-x64.dmg`
+
+- [ ] Make sure that data from the last version appears in the new version OK
+- [ ] Ensure that `brave://version` lists the expected Brave & Chromium versions
+- [ ] With data from the last version, verify that
+  - [ ] Bookmarks on the bookmark toolbar and bookmark folders can be opened
+  - [ ] Cookies are preserved
+  - [ ] Installed extensions are retained and work correctly
+  - [ ] Opened tabs can be reloaded
+  - [ ] Stored passwords are preserved
+  - [ ] Sync chain created in previous version is retained 
+  - [ ] Social media blocking buttons changes are retained
+  - [ ] Rewards
+    - [ ] Wallet balance is retained
+    - [ ] Auto-contribute list is retained
+    - [ ] Both Tips and Monthly Contributions are retained
+    - [ ] Wallet panel transactions list is retained
+    - [ ] Changes to rewards settings are retained
+  - [ ] Ads
+    - [ ] Both `Estimated pending rewards` & `Ad notifications received this month` are retained
+    - [ ] Changes to ads settings are retained
+    - [ ] Ensure that ads are not being enabled when upgrading to a new version if they were disabled
+    - [ ] Ensure that ads are not disabled when upgrading to a new version if they were enabled 


### PR DESCRIPTION
Fix #220

Added wikitemplate-macOS-arm64.md for macOS arm64/M1 testing.