### PR TITLE
Add DNS leak tests for desktop and Android; fixes issue #235

### DIFF
--- a/wikitemplate-android.md
+++ b/wikitemplate-android.md
@@ -51,6 +51,7 @@ Pre-Requisite: Put previous build shortcut on the home screen. Also, have severa
 - [ ] Visit `https://brianbondy.com/` and then turn on script blocking, nothing should load. Allow it from the script blocking UI in the URL bar and it should work.
 - [ ] Verify that default Bravery settings take effect on pages with no site settings
 - [ ] Verify that 3rd party storage results are blank at `https://jsfiddle.net/7ke9r14a/7/` when 3rd party cookies are blocked
+- [ ] Choose a DNS provider from the list in Settings | Privacy | Use Secure DNS, load `https://browserleaks.com/dns`, and verify your ISP's DNS resolvers aren't detected and shown; only your chosen DoH provider should appear.
 ### Fingerprint Tests
   - [ ] Visit `https://browserleaks.com/webrtc`, ensure 2 blocked items are listed in shields
   - [ ] Verify that `https://diafygi.github.io/webrtc-ips/` doesn't leak IP address when `Block all fingerprinting protection` is on

--- a/wikitemplate.md
+++ b/wikitemplate.md
@@ -67,6 +67,8 @@
 - [ ] Visit https://www.blizzard.com and then turn on script blocking, page should not load.
 - [ ] Test that 3rd party storage results are blank at https://jsfiddle.net/7ke9r14a/9/ when 3rd party cookies are blocked and not blank when 3rd party cookies are unblocked
 - [ ] Test that https://mixed-script.badssl.com/ shows up as grey not red (no mixed content scripts are run)
+- [ ] In `brave://settings/security`, choose a DNS provider from the providers listed under Use secure DNS, load `https://browserleaks.com/dns`, and verify your ISP's DNS resolvers aren't detected and shown; only your chosen DoH provider should appear.
+- [ ] Open a New Private Window with Tor, load `https://browserleaks.com/dns`, and verify your ISP's DNS resolvers aren't detected and shown.
 
 ### Fingerprint Tests
 


### PR DESCRIPTION
I tried for parity, but Android doesn't have the scheme handler that we do on desktop, and perfect is the enemy of good.

I'll squash commits before merging, once approved.

r? @kjozwiak @diracdeltas @srirambv?