### PR TITLE
Update wording for Tor button in URL bar

### DIFF
--- a/wikitemplate-tor-Linux.md
+++ b/wikitemplate-tor-Linux.md
@@ -5,7 +5,7 @@
 - [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
 	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
 	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking on `Open in Tor` correctly launches a Tor window and opens the appropriate `.onion` website.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
 
 ### Linux
 - [ ] Navigate to `<user-data-dir>/biahpgbdmdkfgndcmfiipgcebobojjkp`

--- a/wikitemplate-tor-Windows.md
+++ b/wikitemplate-tor-Windows.md
@@ -7,7 +7,7 @@
 - [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
 	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
 	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking on `Open in Tor` correctly launches a Tor window and opens the appropriate `.onion` website.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
 
 ### Windows
 - [ ] Setup Windows SDK by downloading - https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk/
@@ -22,7 +22,7 @@
 - [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
 	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
 	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking on `Open in Tor` correctly launches a Tor window and opens the appropriate `.onion` website.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
 
 ### Windows
 - [ ] Setup Windows SDK by downloading - https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk/

--- a/wikitemplate-tor-macOS(Intel).md
+++ b/wikitemplate-tor-macOS(Intel).md
@@ -7,7 +7,7 @@
 - [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
 	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
 	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking on `Open in Tor` correctly launches a Tor window and opens the appropriate `.onion` website.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
 
 ### MacOS
 - [ ] Navigate to `/Users/<user>/Library/Application Support/BraveSoftware/Brave-Browser-<channel>/cldoidikboihgcjfkhdeidbpclkineef/<version>`
@@ -23,7 +23,7 @@
 - [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
 	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
 	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking on `Open in Tor` correctly launches a Tor window and opens the appropriate `.onion` website.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
 
 ### MacOS
 - [ ] Navigate to `/Users/<user>/Library/Application Support/BraveSoftware/Brave-Browser-<channel>/cldoidikboihgcjfkhdeidbpclkineef/<version>`
@@ -39,7 +39,7 @@
 - [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
 	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
 	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking on `Open in Tor` correctly launches a Tor window and opens the appropriate `.onion` website.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
 
 ### MacOS
 - [ ] Navigate to `/Users/<user>/Library/Application Support/BraveSoftware/Brave-Browser-<channel>/cldoidikboihgcjfkhdeidbpclkineef/<version>`
@@ -55,7 +55,7 @@
 - [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
 	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
 	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking on `Open in Tor` correctly launches a Tor window and opens the appropriate `.onion` website.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
 
 ### MacOS
 - [ ] Navigate to `/Users/<user>/Library/Application Support/BraveSoftware/Brave-Browser-<channel>/cldoidikboihgcjfkhdeidbpclkineef/<version>`
@@ -71,7 +71,7 @@
 - [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
 	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
 	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking on `Open in Tor` correctly launches a Tor window and opens the appropriate `.onion` website.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
 
 ### MacOS
 - [ ] Navigate to `/Users/<user>/Library/Application Support/BraveSoftware/Brave-Browser-<channel>/cldoidikboihgcjfkhdeidbpclkineef/<version>`

--- a/wikitemplate-tor-macOS(arm64).md
+++ b/wikitemplate-tor-macOS(arm64).md
@@ -5,7 +5,7 @@
 - [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
 	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
 	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking on `Open in Tor` correctly launches a Tor window and opens the appropriate `.onion` website.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
 
 ### MacOS
 - [ ] Navigate to `/Users/<user>/Library/Application Support/BraveSoftware/Brave-Browser-<channel>/cldoidikboihgcjfkhdeidbpclkineef/<version>`

--- a/wikitemplate-tor.md
+++ b/wikitemplate-tor.md
@@ -5,7 +5,7 @@
 - [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
 	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
 	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking on `Open in Tor` correctly launches a Tor window and opens the appropriate `.onion` website.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
 
 ### Windows
 - [ ] Setup Windows SDK by downloading - https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk/


### PR DESCRIPTION
Fix #427

Changed wording of `Open in Tor` to be `Tor` to reflect change made with https://github.com/brave/brave-browser/issues/18923.