### PR TITLE
Remove Linux test run generation when release is a minor Chromium bum…

### DIFF
--- a/brave_testrun_generator.py
+++ b/brave_testrun_generator.py
@@ -366,13 +366,6 @@ def laptop_CRminor_testruns(milestonever):
                         "tests" not in label_names):
                     win64_checklist.append(output_line)
 
-                if("QA Pass-Linux" not in label_names and
-                        "OS/Windows" not in label_names and
-                        "OS/macOS" not in label_names and
-                        "QA/No" not in label_names and
-                        "tests" not in label_names):
-                    linux_checklist.append(output_line)
-
     print("\nRelease Notes ")
     for line in release_notes:
         print(line)
@@ -431,22 +424,6 @@ def laptop_CRminor_testruns(milestonever):
                                  labels=winList)
 
     print("--------------------------------------------------------\n")
-
-    print("Linux Checklist:")
-    print(laptop_CRminor_template)
-    print("")
-    linTitle = "Manual test run on Linux for " + milestonever
-    linList = ["OS/Linux",
-               "release-notes/exclude",
-               "tests",
-               "QA/Yes",
-               "OS/Desktop"]
-
-    if args.test is None:
-        bc_repo.create_issue(title=linTitle,
-                                 body=laptop_CRminor_template,
-                                 milestone=bc_milestone[milestonever],
-                                 labels=linList)
 
     return 0
 


### PR DESCRIPTION
…p only

Fix #434

Using "test" mode, confirmed that Linux test run was not created when selection was `3. Desktop Release (Basic checks for minor Chromium bump)` from test run generator.

Using "test" mode, confirmed that Linux test run was created when selection was 1 or 2.