### PR TITLE
Update test run templates to accomodate macOS universal builds

### DIFF
--- a/wikitemplate-ReducedDesktop.md
+++ b/wikitemplate-ReducedDesktop.md
@@ -1,6 +1,9 @@
 ### Installer
 
-- [ ]  Check signature: If OS Run `spctl --assess --verbose /Applications/Brave-Browser-Beta.app/` and make sure it returns `accepted`.  If Windows right click on the `brave_installer-x64.exe` and go to Properties, go to the Digital Signatures tab and double click on the signature.  Make sure it says "The digital signature is OK" in the popup window
+- [ ]  Check signature: 
+  - [ ] If macOS, using x64 binary run `spctl --assess --verbose` for the installed version and make sure it returns `accepted` 
+  - [ ] If macOS, using universal binary run `spctl --assess --verbose` for the installed version and make sure it returns `accepted` 
+  - [ ] If Windows right click on the `brave_installer-x64.exe` and go to Properties, go to the Digital Signatures tab and double click on the signature.  Make sure it says "The digital signature is OK" in the popup window
 
 ### Widevine
 
@@ -8,6 +11,7 @@
 - [ ]  Test that you can stream on Netflix on a fresh profile after installing Widevine
 - [ ]  Verify `Widevine Notification` is shown when you visit HBO Max for the first time
 - [ ]  Test that you can stream on HBO Max on a fresh profile after installing Widevine
+- [ ]  If macOS, run the above Widevine tests for both `x64` and `universal` builds
 
 ### Rewards
 

--- a/wikitemplate-macOS-arm64.md
+++ b/wikitemplate-macOS-arm64.md
@@ -1,23 +1,36 @@
 ### Installer
 
-- [ ]  Check signature: If OS Run `"spctl --assess --verbose /Applications/Brave Browser.app"` and make sure it returns `accepted`.
 - [ ] Ensured that the following executables work as expected
    - [ ] `Brave-Browser-arm64.dmg`
       - [ ] Check executable size, should be `~290mb`
+      - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
    - [ ] `Brave-Browser-arm64.pkg`
        - [ ] Check executable size, should be `~290mb`
+       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
    - [ ] `Brave-Browser-x64.dmg`
        - [ ] Check executable size, should be `~290mb`
+       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
    - [ ] `Brave-Browser-x64.pkg`
        - [ ] Check executable size, should be `~290mb`
+       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
+   - [ ] `Brave-Browser-universal.dmg`
+       - [ ] Check executable size, should be `~500mb`
+       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
+   - [ ] `Brave-Browser-universal.pkg`
+       - [ ] Check executable size, should be `~500mb`
+       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
 - [ ] Visited `brave://version` and ensure the following:
-   - [ ] `arm64` is being displayed when installing via `arm64` binary on `M1` mac
+   - [ ] `arm64` is being displayed when installing via `arm64` and `universal` binaries on `M1` mac
    - [ ] `x86_64 translated` is being displayed when installing via `x64` binary on `M1` mac using `Rosetta`
 
 ### Widevine
 
-- [ ]  Verify `Widevine Notification` is shown when you visit Netflix for the first time
-- [ ]  Test that you can stream on Netflix on a fresh profile after installing Widevine 
+- [ ]  Using `universal` build:
+   - [ ]  Verify `Widevine Notification` is shown when you visit Netflix for the first time
+   - [ ]  Test that you can stream on Netflix on a fresh profile after installing Widevine 
+- [ ]  Using `arm64` build:
+   - [ ]  Verify `Widevine Notification` is shown when you visit Netflix for the first time
+   - [ ]  Test that you can stream on Netflix on a fresh profile after installing Widevine 
 
 #### Components
 - [ ]   Delete Adblock folder from browser profile and restart browser. Visit `brave://components` and verify `Brave Ad Block Updater` downloads and update the component. Repeat for all Brave components
@@ -49,6 +62,21 @@
 
 #### Upgrade - `Brave-Browser-x64.dmg`
 
+- [ ] Make sure that data from the last version appears in the new version OK
+- [ ] Ensure that `brave://version` lists the expected Brave & Chromium versions
+- [ ] With data from the last version, verify that
+  - [ ] Bookmarks on the bookmark toolbar and bookmark folders can be opened
+  - [ ] Cookies are preserved
+  - [ ] Opened tabs can be reloaded
+  - [ ] Stored passwords are preserved
+  - [ ] Sync chain created in previous version is retained 
+  - [ ] Social media blocking buttons changes are retained 
+
+#### Upgrade - `Brave-Browser-universal.dmg`
+
+Pre-requisite: Make sure that the previous version is installed using the universal build
+- [ ] Make sure that after upgrade, the universal build is upgraded to the appropriate architecture specific version
+- [ ] Confirm that the .app file size has decreased as a result of the upgrade
 - [ ] Make sure that data from the last version appears in the new version OK
 - [ ] Ensure that `brave://version` lists the expected Brave & Chromium versions
 - [ ] With data from the last version, verify that

--- a/wikitemplate-minorCRbump-macOS-arm64.md
+++ b/wikitemplate-minorCRbump-macOS-arm64.md
@@ -1,19 +1,27 @@
 ### Installer
 
-- [ ]  Check signature: If OS Run `"spctl --assess --verbose /Applications/Brave Browser.app"` and make sure it returns `accepted`.
 - [ ] Ensured that the following executables work as expected
    - [ ] `Brave-Browser-arm64.dmg`
       - [ ] Check executable size, should be `~290mb`
+      - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
    - [ ] `Brave-Browser-x64.dmg`
        - [ ] Check executable size, should be `~290mb`
+       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
+   - [ ] `Brave-Browser-universal.dmg`
+       - [ ] Check executable size, should be `~500mb`
+       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
 - [ ] Visited `brave://version` and ensure the following:
-   - [ ] `arm64` is being displayed when installing via `arm64` binary on `M1` mac
+   - [ ] `arm64` is being displayed when installing via `arm64` and `universal` binaries on `M1` mac
    - [ ] `x86_64 translated` is being displayed when installing via `x64` binary on `M1` mac using `Rosetta`
 
 ### Widevine
 
-- [ ]  Verify `Widevine Notification` is shown when you visit Netflix for the first time
-- [ ]  Test that you can stream on Netflix on a fresh profile after installing Widevine 
+- [ ]  Using `universal` build:
+   - [ ]  Verify `Widevine Notification` is shown when you visit Netflix for the first time
+   - [ ]  Test that you can stream on Netflix on a fresh profile after installing Widevine 
+- [ ]  Using `arm64` build:
+   - [ ]  Verify `Widevine Notification` is shown when you visit Netflix for the first time
+   - [ ]  Test that you can stream on Netflix on a fresh profile after installing Widevine 
 
 #### Components
 - [ ]   Delete Adblock folder from browser profile and restart browser. Visit `brave://components` and verify `Brave Ad Block Updater` downloads and update the component. Repeat for all Brave components
@@ -42,3 +50,18 @@
     - [ ] Changes to ads settings are retained
     - [ ] Ensure that ads are not being enabled when upgrading to a new version if they were disabled
     - [ ] Ensure that ads are not disabled when upgrading to a new version if they were enabled 
+
+#### Upgrade - `Brave-Browser-universal.dmg`
+
+Pre-requisite: Make sure that the previous version is installed using the universal build
+- [ ] Make sure that after upgrade, the universal build is upgraded to the appropriate architecture specific version
+- [ ] Confirm that the .app file size has decreased as a result of the upgrade
+- [ ] Make sure that data from the last version appears in the new version OK
+- [ ] Ensure that `brave://version` lists the expected Brave & Chromium versions
+- [ ] With data from the last version, verify that
+  - [ ] Bookmarks on the bookmark toolbar and bookmark folders can be opened
+  - [ ] Cookies are preserved
+  - [ ] Opened tabs can be reloaded
+  - [ ] Stored passwords are preserved
+  - [ ] Sync chain created in previous version is retained 
+  - [ ] Social media blocking buttons changes are retained 

--- a/wikitemplate-minorCRbumpDesktop.md
+++ b/wikitemplate-minorCRbumpDesktop.md
@@ -1,11 +1,15 @@
 ### Installer
 
-- [ ]  Check signature: If OS Run `spctl --assess --verbose /Applications/Brave-Browser-Beta.app/` and make sure it returns `accepted`.  If Windows right click on the `brave_installer-x64.exe` and go to Properties, go to the Digital Signatures tab and double click on the signature.  Make sure it says "The digital signature is OK" in the popup window
+- [ ]  Check signature: 
+  - [ ] If macOS, using x64 binary run `spctl --assess --verbose` for the installed version and make sure it returns `accepted` 
+  - [ ] If macOS, using universal binary run `spctl --assess --verbose` for the installed version and make sure it returns `accepted` 
+  - [ ] If Windows right click on the `brave_installer-x64.exe` and go to Properties, go to the Digital Signatures tab and double click on the signature.  Make sure it says "The digital signature is OK" in the popup window
 
 ### Widevine
 
 - [ ]  Verify `Widevine Notification` is shown when you visit Netflix for the first time
 - [ ]  Test that you can stream on Netflix on a fresh profile after installing Widevine
+- [ ]  If macOS, run the above Widevine tests for both `x64` and `universal` builds
 
 ### Rewards
 

--- a/wikitemplate.md
+++ b/wikitemplate.md
@@ -1,7 +1,10 @@
 ### Installer
 
 - [ ] Check the installer is close to the size of the last release
-- [ ] Check signature: On macOS, run `spctl --assess --verbose /Applications/Brave-Browser-Beta.app/` and make sure it returns `accepted`.  On Windows, right-click on the `brave_installer-x64.exe` and go to Properties, go to the Digital Signatures tab and double-click on the signature.  Make sure it says "The digital signature is OK" in the popup window
+- [ ]  Check signature: 
+  - [ ] If macOS, using x64 binary run `spctl --assess --verbose` for the installed version and make sure it returns `accepted` 
+  - [ ] If macOS, using universal binary run `spctl --assess --verbose` for the installed version and make sure it returns `accepted` 
+  - [ ] If Windows right click on the `brave_installer-x64.exe` and go to Properties, go to the Digital Signatures tab and double click on the signature.  Make sure it says "The digital signature is OK" in the popup window
 
 ### About pages
 
@@ -46,6 +49,7 @@
 - [ ] Test that you can stream on Netflix on a fresh profile after installing Widevine
 - [ ] Verify `Widevine Notification` is shown when you visit HBO Max for the first time
 - [ ] Test that you can stream on HBO Max on a fresh profile after installing Widevine
+- [ ] If macOS, run the above Widevine tests for both `x64` and `universal` builds
 
 ### Geolocation
 


### PR DESCRIPTION
Fix #440

Updated various templates to accommodate macOS universal builds