### PR TITLE
Update Desktop test runs to include TLS Pinning check

### DIFF
--- a/wikitemplate-ReducedDesktop.md
+++ b/wikitemplate-ReducedDesktop.md
@@ -28,6 +28,10 @@
 - [ ]  Verify you are able to perform a contribution
 - [ ]  Verify if you disable auto-contribute you are still able to tip regular sites and YouTube creators
 
+### TLS Pinning
+
+- [ ] Visit https://ssl-pinning.someblog.org/ and verify a pinning error is displayed
+
 ## Update tests
 
 - [ ]  Verify visiting `brave://settings/help` triggers update check

--- a/wikitemplate-minorCRbumpDesktop.md
+++ b/wikitemplate-minorCRbumpDesktop.md
@@ -15,6 +15,10 @@
 
 - [ ] Verify that you are able to successfully join Rewards on a fresh profile
 
+### TLS Pinning
+
+- [ ] Visit https://ssl-pinning.someblog.org/ and verify a pinning error is displayed
+
 ## Update tests
 
 - [ ]  Verify visiting `brave://settings/help` triggers update check

--- a/wikitemplate.md
+++ b/wikitemplate.md
@@ -74,6 +74,10 @@
 - [ ] In `brave://settings/security`, choose a DNS provider from the providers listed under Use secure DNS, load `https://browserleaks.com/dns`, and verify your ISP's DNS resolvers aren't detected and shown; only your chosen DoH provider should appear.
 - [ ] Open a New Private Window with Tor, load `https://browserleaks.com/dns`, and verify your ISP's DNS resolvers aren't detected and shown.
 
+### TLS Pinning
+
+- [ ] Visit https://ssl-pinning.someblog.org/ and verify a pinning error is displayed
+
 ### Fingerprint Tests
 
 - [ ] Visit https://jsfiddle.net/bkf50r8v/13/, ensure 3 blocked items are listed in Shields. Result window should show `got canvas fingerprint 0` and `got webgl fingerprint 00`


### PR DESCRIPTION
Fix #450

Added TLS pinning check to:
- `wikitemplate.md` (full desktop manual pass, run for each major Chromium bump)
- `wikitemplate-minorCRbumpDesktop.md` (reduced desktop manual pass, run for each minor Chromium bump that is done on Release Channel)
- `wikitemplate-ReducedDesktop.md` (reduced desktop manual pass, run for hot fixes that do not contain a minor Chromium bump)