### PR TITLE
Update Desktop tests to expand TLS Pinning check

### DIFF
--- a/wikitemplate-ReducedDesktop.md
+++ b/wikitemplate-ReducedDesktop.md
@@ -31,6 +31,7 @@
 ### TLS Pinning
 
 - [ ] Visit https://ssl-pinning.someblog.org/ and verify a pinning error is displayed
+- [ ] Visit https://pinning-test.badssl.com/ and verify a pinning error is **not** displayed
 
 ## Update tests
 

--- a/wikitemplate-minorCRbumpDesktop.md
+++ b/wikitemplate-minorCRbumpDesktop.md
@@ -18,6 +18,7 @@
 ### TLS Pinning
 
 - [ ] Visit https://ssl-pinning.someblog.org/ and verify a pinning error is displayed
+- [ ] Visit https://pinning-test.badssl.com/ and verify a pinning error is **not** displayed
 
 ## Update tests
 

--- a/wikitemplate.md
+++ b/wikitemplate.md
@@ -77,6 +77,7 @@
 ### TLS Pinning
 
 - [ ] Visit https://ssl-pinning.someblog.org/ and verify a pinning error is displayed
+- [ ] Visit https://pinning-test.badssl.com/ and verify a pinning error is **not** displayed
 
 ### Fingerprint Tests
 


### PR DESCRIPTION
This is only valid once https://github.com/brave/security/issues/990 has been merged, but it will ensure that we don't accidentally regress on https://github.com/brave/brave-browser/issues/24454.

Note that it's related to what was done in #452. That other one was to check that Brave pins are enforced, this new one is to check that Google pins are **not** enforced.