### PR TITLE
Remove unnecessary test; fixes issue #466

### DIFF
--- a/wikitemplate-IPFS.md
+++ b/wikitemplate-IPFS.md
@@ -256,7 +256,6 @@
 - [ ] Verify the setting is enabled by default.
 - [ ] Verify disable/enable setting is retained between browser launch/restarts.
 - [ ] Verify setting state is retained during upgrade.
-- [ ] Verify you can't change the IPFS public gateway address to `https://cloudflare-ipfs.com/` (An error `Only a valid IPFS gateway with Origin isolation enabled can be used in Brave` is displayed – [example](https://github.com/brave/brave-browser/issues/18212#issuecomment-923632150)).
 - [ ] Verify you can change the IPFS public gateway address to `https://cf-ipfs.com/`  (passes the Origin isolation test).
 
 ### `IPFS/IPNS URI`


### PR DESCRIPTION
`IPFS Gateway` is currently just an `Enabled`/`Disabled` toggle.

Remove its test.

![Screenshot_20220831-103319](https://user-images.githubusercontent.com/387249/187742912-d707626b-68d4-4b58-8a80-32e9f882eb9e.png)

