### PR TITLE
Fixes issue 477: Add another test for ENS domains

### DIFF
--- a/wikitemplate-IPFS.md
+++ b/wikitemplate-IPFS.md
@@ -158,6 +158,7 @@
    - [ ] `ipns://en.wikipedia-on-ipfs.org/wiki/Tokyo#Islands`
    - [ ] `ipns://docs.ipfs.io`
    - [ ] `ipns://brantly.eth` (ENS)
+   - [ ] `ipns://vitalik.eth` (ENS)
    - [ ] `ipns://brad.crypto` (Unstoppable Domains)
 
 ## Gateway choice


### PR DESCRIPTION
Add another test -- `vitalik.eth` -- to the ENS portion of the IPFS manual run.

Fixes https://github.com/brave/qa-resources/issues/477.