### PR TITLE
Fixes #489: remove outdated Uphold tests on Android

### DIFF
--- a/WikiTemplate/Android/wikitemplate-ReducedAndroid.md
+++ b/WikiTemplate/Android/wikitemplate-ReducedAndroid.md
@@ -30,7 +30,6 @@
 - [ ] Verify you can tip a verified YouTube creator
 - [ ] Verify you are able to perform a contribution
 - [ ] Verify if you disable auto-contribute you are still able to tip regular sites and YouTube creators
-- [ ] Verify on BR panel that the `Verify wallet` button only enables when balance is >=15 BAT
 - [ ] Verify you can reset rewards from advance setting. Resetting should delete wallet and bring it back to the pre-optin state
 
 ## Brave Shields

--- a/WikiTemplate/Android/wikitemplate-android.md
+++ b/WikiTemplate/Android/wikitemplate-android.md
@@ -96,8 +96,7 @@
 - [ ] Verify unchecking `Allow contribution to videos` option doesn't list any YouTube creator in ac list
 - [ ] Adjust min visit/time in settings. Visit some sites and YouTube channels to verify they are added to the table after the specified settings
 - [ ] Verify you can reset rewards from advance setting. Resetting should delete wallet and bring it back to the pre-optin state
-- [ ] Verify user still able to connect to existing Uphold account via panel even when balance is < 2 BAT
-- [ ] Verify you are able to disconnect/re-connect a user wallet
+- [ ] Verify you are able to connect, disconnect, and re-connect a KYC'd (Uphold, etc.) user wallet
 - [ ] Upgrade from an older version
   - [ ] Verify the wallet balance (if available) is retained
   - [ ] Verify auto-contribute list is not lost after upgrade

--- a/WikiTemplate/Android/wikitemplate-android.md
+++ b/WikiTemplate/Android/wikitemplate-android.md
@@ -96,7 +96,7 @@
 - [ ] Verify unchecking `Allow contribution to videos` option doesn't list any YouTube creator in ac list
 - [ ] Adjust min visit/time in settings. Visit some sites and YouTube channels to verify they are added to the table after the specified settings
 - [ ] Verify you can reset rewards from advance setting. Resetting should delete wallet and bring it back to the pre-optin state
-- [ ] Verify you are able to connect, disconnect, and re-connect a KYC'd (Uphold, etc.) user wallet
+- [ ] Verify you are able to connect, disconnect, and re-connect a KYC'd user wallet (Uphold, Gemini, etc.)
 - [ ] Upgrade from an older version
   - [ ] Verify the wallet balance (if available) is retained
   - [ ] Verify auto-contribute list is not lost after upgrade

--- a/WikiTemplate/Android/wikitemplate-android.md
+++ b/WikiTemplate/Android/wikitemplate-android.md
@@ -96,7 +96,6 @@
 - [ ] Verify unchecking `Allow contribution to videos` option doesn't list any YouTube creator in ac list
 - [ ] Adjust min visit/time in settings. Visit some sites and YouTube channels to verify they are added to the table after the specified settings
 - [ ] Verify you can reset rewards from advance setting. Resetting should delete wallet and bring it back to the pre-optin state
-- [ ] Verify on BR panel `Verify wallet` button loads verify wallet page when balance in >=2 BAT.
 - [ ] Verify user still able to connect to existing Uphold account via panel even when balance is < 2 BAT
 - [ ] Verify you are able to disconnect/re-connect a user wallet
 - [ ] Upgrade from an older version


### PR DESCRIPTION
LMK if you want me to include the `- [ ] Verify user still able to connect to existing Uphold account via panel even when balance is < 2 BAT` test too