### PR TITLE
Remove references to macOS x64 builds in macOS arm64 manual passes

### DIFF
--- a/WikiTemplate/Desktop/Minor_CR_Bump/wikitemplate-minorCRbump-macOS-arm64.md
+++ b/WikiTemplate/Desktop/Minor_CR_Bump/wikitemplate-minorCRbump-macOS-arm64.md
@@ -4,15 +4,11 @@
    - [ ] `Brave-Browser-arm64.dmg`
       - [ ] Check executable size, should be `~290mb`
       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
-   - [ ] `Brave-Browser-x64.dmg`
-       - [ ] Check executable size, should be `~290mb`
-       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
    - [ ] `Brave-Browser-universal.dmg`
        - [ ] Check executable size, should be `~500mb`
        - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
 - [ ] Visited `brave://version` and ensure the following:
    - [ ] `arm64` is being displayed when installing via `arm64` and `universal` binaries on `M1` mac
-   - [ ] `x86_64 translated` is being displayed when installing via `x64` binary on `M1` mac using `Rosetta`
 
 ### Widevine
 

--- a/WikiTemplate/Desktop/wikitemplate-macOS-arm64.md
+++ b/WikiTemplate/Desktop/wikitemplate-macOS-arm64.md
@@ -7,12 +7,6 @@
    - [ ] `Brave-Browser-arm64.pkg`
        - [ ] Check executable size, should be `~290mb`
        - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
-   - [ ] `Brave-Browser-x64.dmg`
-       - [ ] Check executable size, should be `~290mb`
-       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
-   - [ ] `Brave-Browser-x64.pkg`
-       - [ ] Check executable size, should be `~290mb`
-       - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
    - [ ] `Brave-Browser-universal.dmg`
        - [ ] Check executable size, should be `~500mb`
        - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
@@ -21,7 +15,6 @@
        - [ ]  Check signature: If OS Run `spctl --assess --verbose` for the installed version and make sure it returns `accepted`.
 - [ ] Visited `brave://version` and ensure the following:
    - [ ] `arm64` is being displayed when installing via `arm64` and `universal` binaries on `M1` mac
-   - [ ] `x86_64 translated` is being displayed when installing via `x64` binary on `M1` mac using `Rosetta`
 
 ### Widevine
 
@@ -59,18 +52,6 @@
     - [ ] Changes to ads settings are retained
     - [ ] Ensure that ads are not being enabled when upgrading to a new version if they were disabled
     - [ ] Ensure that ads are not disabled when upgrading to a new version if they were enabled 
-
-#### Upgrade - `Brave-Browser-x64.dmg`
-
-- [ ] Make sure that data from the last version appears in the new version OK
-- [ ] Ensure that `brave://version` lists the expected Brave & Chromium versions
-- [ ] With data from the last version, verify that
-  - [ ] Bookmarks on the bookmark toolbar and bookmark folders can be opened
-  - [ ] Cookies are preserved
-  - [ ] Opened tabs can be reloaded
-  - [ ] Stored passwords are preserved
-  - [ ] Sync chain created in previous version is retained 
-  - [ ] Social media blocking buttons changes are retained 
 
 #### Upgrade - `Brave-Browser-universal.dmg`
 


### PR DESCRIPTION
Fix #488

Removed references to x64 builds on the arm64 manual passes for macOS.