### PR TITLE
Fix issue #514 - update pref wording

### DIFF
--- a/WikiTemplate/Desktop/wikitemplate.md
+++ b/WikiTemplate/Desktop/wikitemplate.md
@@ -149,8 +149,8 @@
 - [ ] visit `brave://settings/privacy` -> `Site and Shields Settings` -> `Cookies and site data` and ensure that
   - [ ] both `https://[*.]firebaseapp.com` & `https://accounts.google.com` are added into `Sites that can always use cookies` when `Allow Google login buttons on third party sites` is enabled
   - [ ] both `https://[*.]firebaseapp.com` & `https://accounts.google.com` are removed from `Sites that can always use cookies` when `Allow Google login buttons on third party sites` is disabled
-- [ ] ensure that you can log in into https://www.expensify.com while `Allow Google login buttons on third party sites` is enabled
-- [ ] ensure that once `Allow Google login buttons on third party sites` has been disabled, you can't log in into https://www.expensify.com
+- [ ] ensure that you can log in into https://www.expensify.com while `Allow use of third-party cookies for legacy Google Sign-In` is enabled
+- [ ] ensure that once `Allow use of third-party cookies for legacy Google Sign-In` has been disabled, you can't log in into https://www.expensify.com
 
 ### Sync
 


### PR DESCRIPTION
Change from `Allow Google login buttons on third-party sites` to `Allow use of third-party cookies for legacy Google Sign-In`

@kjozwiak @LaurenWags @srirambv r?