### PR TITLE
Update wikitemplate-android.md

### DIFF
--- a/WikiTemplate/Android/wikitemplate-android.md
+++ b/WikiTemplate/Android/wikitemplate-android.md
@@ -25,7 +25,7 @@
 ## Tab Groups
 
 - [ ] Ensure tab-group is enabled by default
-- [ ] Verify toggling tab-group setting triggers a relaunch request
+- [ ] Verify toggling tab-group setting doesn't trigger a relaunch request
 - [ ] Verify tab-group is not reverted back to default setting after browser restart
 
 ## Developer Tools

--- a/WikiTemplate/Android/wikitemplate-android.md
+++ b/WikiTemplate/Android/wikitemplate-android.md
@@ -25,8 +25,7 @@
 ## Tab Groups
 
 - [ ] Ensure tab-group is enabled by default
-- [ ] Verify toggling tab-group setting doesn't trigger a relaunch request
-- [ ] Verify tab-group is not reverted back to default setting after browser restart
+- [ ] Verify tab-group is not reverted back to default setting when changing it and then restarting the browser
 
 ## Developer Tools
 


### PR DESCRIPTION
- Removed test case `Verify toggling tab-group setting doesn't trigger a relaunch request`
- Updating test case `Verify tab-group is not reverted back to default setting after browser restart` to `Verify tab-group is not reverted back to default setting when changing it and then restarting the browser`. 

This behavior was introduced in build `1.58.x`.