### PR TITLE
Removed HTTPSE check from desktop manual passes

### DIFF
--- a/WikiTemplate/Desktop/Major_CR_Bump/wikitemplate-majorChromiumBumpUpgrades.md
+++ b/WikiTemplate/Desktop/Major_CR_Bump/wikitemplate-majorChromiumBumpUpgrades.md
@@ -11,7 +11,6 @@ As per process, QA runs through the following cases to ensure that the major chr
   - [ ] `gkboaolpopklhgplhaaiboijnklogmbc`: Brave Ad Block List Catalog
   - [ ] `iodkpdagapdfkphljnddpjlldadblomo`: Brave Ad Block Updater
   - [ ] `mfddibmblmbccpadfndgakiopmmhebop`: Brave Ad Block List Catalog
-  - [ ] `oofiananboodjbbmdelgdommihjbkfag`: HTTPSE
   - [ ] `Safe Browsing`
 - [ ] Restart the browser, load `brave://components`, wait for 8 mins and verify that no component shows any errors
 

--- a/WikiTemplate/Desktop/wikitemplate.md
+++ b/WikiTemplate/Desktop/wikitemplate.md
@@ -193,7 +193,6 @@
   - [ ] `CertificateRevocation`
   - [ ] `cffkpbalmllkdoenhmdmpbkajipdjfam`: `rs-ABPFilterParserData.dat` & `regional_catalog.json` (AdBlock)
   - [ ] `gccbbckogglekeggclmmekihdgdpdgoe`: (Sponsored New Tab Images)
-  - [ ] `oofiananboodjbbmdelgdommihjbkfag`: HTTPSE
   - [ ] `Safe Browsing`
 - [ ] Restart the browser, load `brave://components`, wait for 8 mins and verify that no component shows any errors
 


### PR DESCRIPTION
Fix #554

Removed deprecated HTTPSE check from:
- `wikitemplate-majorChromiumBumpUpgrades.md`
- `wikitemplate.md`