### PR TITLE
Fix test run generator for full manual passes

### DIFF
--- a/brave_testrun_generator.py
+++ b/brave_testrun_generator.py
@@ -141,7 +141,7 @@ def laptop_testruns(milestonever):
                "OS/Desktop"]
 
     if args.test is None:
-        bc_repo.create_issue(title=macTitle,
+        bc_repo.create_issue(title=macx64Title,
                                  body=macOS_x64,
                                  milestone=bc_milestone[milestonever],
                                  labels=macx64List)


### PR DESCRIPTION
Fix #603

Fix error:

```
Traceback (most recent call last):
  File "brave_testrun_generator.py", line 933, in <module>
    laptop_testruns(sorted(bc_milestone.keys())[0])
  File "brave_testrun_generator.py", line 144, in laptop_testruns
    bc_repo.create_issue(title=macTitle,
NameError: name 'macTitle' is not defined
```

Line 136 was updated but line 144 was not, PR updates line 144.