### PR TITLE
Update macOS Tor Templates

### DIFF
--- a/WikiTemplate/Tor/wikitemplate-tor-macOS(Intel).md
+++ b/WikiTemplate/Tor/wikitemplate-tor-macOS(Intel).md
@@ -1,3 +1,19 @@
+### **`macOS 15.x Sequoia`**
+
+### Tor Client Updater
+
+- [ ] For development go-update-server. Run brave-browser with `--user-data-dir=component-dev --use-dev-goupdater-url` (These flags are only available in v1.7.x). Once the crx is pushed to production run without these flags.
+- [ ] Navigate to `brave://components` and verify `Tor Client Updater (OS)` is updated successfully.
+- [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
+	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
+	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
+- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
+
+### MacOS
+- [ ] Navigate to `/Users/<user>/Library/Application Support/BraveSoftware/Brave-Browser-<channel>/cldoidikboihgcjfkhdeidbpclkineef/<version>`
+- [ ] Run `codesign -vvvv tor-<version-tor>-darwin-brave-<version-brave>` to confirm codesign is valid
+- [ ] For MacOS Catalina (10.15+) - Run `spctl -a -vv -t install tor-<version-tor>-darwin-brave-<version-brave>` to verify that the binary is notarized.
+
 ### **`macOS 14.x Sonoma`**
 
 ### Tor Client Updater
@@ -31,38 +47,6 @@
 - [ ] For MacOS Catalina (10.15+) - Run `spctl -a -vv -t install tor-<version-tor>-darwin-brave-<version-brave>` to verify that the binary is notarized.
 
 ### **`macOS 12.x Monterey`**
-
-### Tor Client Updater
-
-- [ ] For development go-update-server. Run brave-browser with `--user-data-dir=component-dev --use-dev-goupdater-url` (These flags are only available in v1.7.x). Once the crx is pushed to production run without these flags.
-- [ ] Navigate to `brave://components` and verify `Tor Client Updater (OS)` is updated successfully.
-- [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
-	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
-	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
-
-### MacOS
-- [ ] Navigate to `/Users/<user>/Library/Application Support/BraveSoftware/Brave-Browser-<channel>/cldoidikboihgcjfkhdeidbpclkineef/<version>`
-- [ ] Run `codesign -vvvv tor-<version-tor>-darwin-brave-<version-brave>` to confirm codesign is valid
-- [ ] For MacOS Catalina (10.15+) - Run `spctl -a -vv -t install tor-<version-tor>-darwin-brave-<version-brave>` to verify that the binary is notarized.
-
-### **`macOS 11.x Big Sur`**
-
-### Tor Client Updater
-
-- [ ] For development go-update-server. Run brave-browser with `--user-data-dir=component-dev --use-dev-goupdater-url` (These flags are only available in v1.7.x). Once the crx is pushed to production run without these flags.
-- [ ] Navigate to `brave://components` and verify `Tor Client Updater (OS)` is updated successfully.
-- [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
-	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
-	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
-
-### MacOS
-- [ ] Navigate to `/Users/<user>/Library/Application Support/BraveSoftware/Brave-Browser-<channel>/cldoidikboihgcjfkhdeidbpclkineef/<version>`
-- [ ] Run `codesign -vvvv tor-<version-tor>-darwin-brave-<version-brave>` to confirm codesign is valid
-- [ ] For MacOS Catalina (10.15+) - Run `spctl -a -vv -t install tor-<version-tor>-darwin-brave-<version-brave>` to verify that the binary is notarized.
-
-### **`macOS 10.15.x Catalina`**
 
 ### Tor Client Updater
 

--- a/WikiTemplate/Tor/wikitemplate-tor-macOS(arm64).md
+++ b/WikiTemplate/Tor/wikitemplate-tor-macOS(arm64).md
@@ -1,20 +1,4 @@
-### **`macOS 14.x Sonoma`**
-
-### Tor Client Updater
-
-- [ ] For development go-update-server. Run brave-browser with `--user-data-dir=component-dev --use-dev-goupdater-url` (These flags are only available in v1.7.x). Once the crx is pushed to production run without these flags.
-- [ ] Navigate to `brave://components` and verify `Tor Client Updater (OS)` is updated successfully.
-- [ ] Open `New Private Window with Tor` and confirm that it starts without any errors.
-	- [ ] Navigate to `check.torproject.org` and verify that tor is working successfully.
-	- [ ] Navigate to `brave.com` and `http://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/` to check if the sites work correctly.
-- [ ] Load `brave.com` and `mail.protonmail.com` in a regular Window/Tab and ensure that clicking the `Tor` button in the URL bar correctly launches a Tor window and opens the appropriate `.onion` website.
-
-### MacOS
-- [ ] Navigate to `/Users/<user>/Library/Application Support/BraveSoftware/Brave-Browser-<channel>/cldoidikboihgcjfkhdeidbpclkineef/<version>`
-- [ ] Run `codesign -vvvv tor-<version-tor>-darwin-brave-<version-brave>` to confirm codesign is valid
-- [ ] For MacOS Catalina (10.15+) - Run `spctl -a -vv -t install tor-<version-tor>-darwin-brave-<version-brave>` to verify that the binary is notarized.
-
-### **`macOS 13.x Ventura`**
+### **`macOS 15.x Sequoia`**
 
 ### Tor Client Updater
 


### PR DESCRIPTION
Fix #607

For macOS x64/Intel:
- Added 15.x Sequoia section as this was not included
- Removed 10.15.x Catalina section as this version is no longer supported
- Removed 11.x Big Sur section as this version is no longer supported

For macOS arm64/M1:
- Updated this so we only have one section for 15.x Sequoia, as per internal discussion this is currently the only version QA has on their arm64 laptops.